### PR TITLE
fix(wabe): search hooks should be trigger in priority 2

### DIFF
--- a/packages/wabe/src/hooks/index.ts
+++ b/packages/wabe/src/hooks/index.ts
@@ -313,12 +313,14 @@ export const getDefaultHooks = (): Hook<any, any>[] => [
   },
   {
     operationType: OperationType.BeforeCreate,
-    priority: 1,
+    // Need to be after email setup
+    priority: 2,
     callback: defaultSearchableFieldsBeforeCreate,
   },
   {
     operationType: OperationType.BeforeUpdate,
-    priority: 1,
+    // Need to be after email setup
+    priority: 2,
     callback: defaultSearchableFieldsBeforeUpdate,
   },
   {

--- a/packages/wabe/src/utils/helper.ts
+++ b/packages/wabe/src/utils/helper.ts
@@ -112,6 +112,7 @@ export const setupTests = async (
               type: 'Phone',
             },
           },
+          searchableFields: ['email'],
           permissions: {
             update: {
               requireAuthentication: false,


### PR DESCRIPTION
We need to before run all other hooks like email setUp before searchableFields