### PR TITLE
fix(wabe): remove permission check to send OTP code

### DIFF
--- a/packages/wabe/src/schema/resolvers/sendOtpCode.test.ts
+++ b/packages/wabe/src/schema/resolvers/sendOtpCode.test.ts
@@ -14,7 +14,6 @@ import {
   setupTests,
   getGraphqlClient,
   closeTests,
-  getAnonymousClient,
 } from '../../utils/helper'
 import { EmailDevAdapter } from '../../email/DevAdapter'
 

--- a/packages/wabe/src/schema/resolvers/sendOtpCode.test.ts
+++ b/packages/wabe/src/schema/resolvers/sendOtpCode.test.ts
@@ -40,16 +40,6 @@ describe('sendOtpCodeResolver', () => {
     spySend.mockClear()
   })
 
-  it('should throw an error if the user is not authenticated', async () => {
-    expect(
-      getAnonymousClient(port).request<any>(graphql.sendOtpCode, {
-        input: {
-          email: 'toto@toto.fr',
-        },
-      }),
-    ).rejects.toThrow('Permission denied')
-  })
-
   it('should use the provided email template if provided', async () => {
     const previous = wabe.config.email
     // @ts-expect-error

--- a/packages/wabe/src/schema/resolvers/sendOtpCode.ts
+++ b/packages/wabe/src/schema/resolvers/sendOtpCode.ts
@@ -9,8 +9,6 @@ export const sendOtpCodeResolver = async (
   { input }: MutationSendOtpCodeArgs,
   context: WabeContext<DevWabeTypes>,
 ) => {
-  if (!context.user && !context.isRoot) throw new Error('Permission denied')
-
   const emailController = context.wabe.controllers.email
 
   if (!emailController) throw new Error('Email adapter not defined')


### PR DESCRIPTION
We can send OTP as anonymous client, for example for reset password :)