### PR TITLE
fix(wabe): remove mandatory read operations on CUD operations

### DIFF
--- a/packages/wabe/src/authentication/Session.test.ts
+++ b/packages/wabe/src/authentication/Session.test.ts
@@ -48,7 +48,7 @@ describe('_Session', () => {
         accessToken: { equalTo: 'accessToken' },
       },
       first: 1,
-      fields: ['user.*', 'user.role.*'],
+      fields: ['user.*', 'user.role.*', 'id'],
       context: { isRoot: true, wabe: { controllers } },
     })
   })
@@ -80,7 +80,7 @@ describe('_Session', () => {
         accessToken: { equalTo: 'accessToken' },
       },
       first: 1,
-      fields: ['user.*', 'user.role.*'],
+      fields: ['user.*', 'user.role.*', 'id'],
       context: expect.any(Object),
     })
 

--- a/packages/wabe/src/authentication/Session.ts
+++ b/packages/wabe/src/authentication/Session.ts
@@ -73,7 +73,7 @@ export class Session {
       import.meta.env.JWT_SECRET || 'dev',
     )
 
-    const { id } = await context.wabe.controllers.database.createObject({
+    const res = await context.wabe.controllers.database.createObject({
       className: '_Session',
       context,
       data: {
@@ -89,10 +89,12 @@ export class Session {
       fields: ['id'],
     })
 
+    if (!res) throw new Error('Session not created')
+
     return {
       accessToken: this.accessToken,
       refreshToken: this.refreshToken,
-      sessionId: id,
+      sessionId: res.id,
     }
   }
 
@@ -141,6 +143,8 @@ export class Session {
         accessToken: null,
         refreshToken: null,
       }
+
+    if (!session[0]) throw new Error('Session not found')
 
     const {
       refreshTokenExpiresAt,

--- a/packages/wabe/src/authentication/Session.ts
+++ b/packages/wabe/src/authentication/Session.ts
@@ -41,7 +41,7 @@ export class Session {
         accessToken: { equalTo: accessToken },
       },
       first: 1,
-      fields: ['user.*', 'user.role.*'],
+      fields: ['user.*', 'user.role.*', 'id'],
       context,
     })
 

--- a/packages/wabe/src/authentication/providers/EmailPassword.ts
+++ b/packages/wabe/src/authentication/providers/EmailPassword.ts
@@ -33,7 +33,7 @@ export class EmailPassword
         ...context,
         isRoot: true,
       },
-      fields: ['authentication'],
+      fields: ['id', 'authentication'],
       first: 1,
     })
 

--- a/packages/wabe/src/authentication/providers/EmailPassword.ts
+++ b/packages/wabe/src/authentication/providers/EmailPassword.ts
@@ -42,7 +42,7 @@ export class EmailPassword
 
     const user = users[0]
 
-    const userDatabasePassword = user.authentication?.emailPassword?.password
+    const userDatabasePassword = user?.authentication?.emailPassword?.password
 
     if (!userDatabasePassword)
       throw new Error('Invalid authentication credentials')
@@ -115,10 +115,10 @@ export class EmailPassword
 
     return {
       authenticationDataToSave: {
-        email: input.email ?? user.authentication?.emailPassword?.email,
+        email: input.email ?? user?.authentication?.emailPassword?.email,
         password: input.password
           ? await hashPassword(input.password)
-          : user.authentication?.emailPassword?.password,
+          : user?.authentication?.emailPassword?.password,
       },
     }
   }

--- a/packages/wabe/src/authentication/providers/Google.test.ts
+++ b/packages/wabe/src/authentication/providers/Google.test.ts
@@ -3,7 +3,7 @@ import { Google } from './Google'
 import { Google as GoogleOauth } from '../oauth/Google'
 import { AuthenticationProvider } from '../interface'
 
-describe('Google oauth', () => {
+describe('Google providers', () => {
   const mockGetObjects = mock(() => Promise.resolve([]))
   const mockCount = mock(() => Promise.resolve(0)) as any
   const mockCreateObject = mock(() => Promise.resolve({ id: 'userId' })) as any
@@ -99,7 +99,7 @@ describe('Google oauth', () => {
         },
       },
       context: expect.any(Object),
-      fields: ['*'],
+      fields: ['*', 'id'],
     })
 
     mockValidateAuthorizationCode.mockRestore()

--- a/packages/wabe/src/authentication/providers/Google.ts
+++ b/packages/wabe/src/authentication/providers/Google.ts
@@ -79,7 +79,7 @@ export class Google implements ProviderInterface<GoogleInterface> {
           ...context,
           isRoot: true,
         },
-        fields: ['*'],
+        fields: ['*', 'id'],
       })
 
       if (!createdUser) throw new Error('User not found')

--- a/packages/wabe/src/authentication/providers/Google.ts
+++ b/packages/wabe/src/authentication/providers/Google.ts
@@ -82,6 +82,8 @@ export class Google implements ProviderInterface<GoogleInterface> {
         fields: ['*'],
       })
 
+      if (!createdUser) throw new Error('User not found')
+
       return {
         user: createdUser,
         oauth: {
@@ -92,6 +94,8 @@ export class Google implements ProviderInterface<GoogleInterface> {
         },
       }
     }
+
+    if (!user[0]) throw new Error('User not found')
 
     return {
       user: user[0],

--- a/packages/wabe/src/authentication/resolvers/signUpWithResolver.ts
+++ b/packages/wabe/src/authentication/resolvers/signUpWithResolver.ts
@@ -16,7 +16,7 @@ export const signUpWithResolver = async (
   context: WabeContext<any>,
 ) => {
   // Create object call the provider signUp
-  const { id: userId } = await context.wabe.controllers.database.createObject({
+  const res = await context.wabe.controllers.database.createObject({
     className: 'User',
     data: {
       authentication: input.authentication,
@@ -30,7 +30,9 @@ export const signUpWithResolver = async (
 
   const session = new Session()
 
-  const { accessToken, refreshToken } = await session.create(userId, {
+  if (!res) throw new Error('User not created')
+
+  const { accessToken, refreshToken } = await session.create(res.id, {
     ...context,
     isRoot: true,
   })
@@ -53,5 +55,5 @@ export const signUpWithResolver = async (
     })
   }
 
-  return { accessToken, refreshToken, id: userId }
+  return { accessToken, refreshToken, id: res.id }
 }

--- a/packages/wabe/src/authentication/roles.test.ts
+++ b/packages/wabe/src/authentication/roles.test.ts
@@ -27,7 +27,7 @@ describe('roles', () => {
     })
 
     expect(res.length).toEqual(3)
-    expect(res.map((role) => role.name)).toEqual([
+    expect(res.map((role) => role?.name)).toEqual([
       'Client',
       'Client2',
       'Client3',
@@ -47,7 +47,7 @@ describe('roles', () => {
     })
 
     expect(res.length).toEqual(3)
-    expect(res.map((role) => role.name)).toEqual([
+    expect(res.map((role) => role?.name)).toEqual([
       'Client',
       'Client2',
       'Client3',

--- a/packages/wabe/src/authentication/roles.ts
+++ b/packages/wabe/src/authentication/roles.ts
@@ -1,5 +1,5 @@
 import type { Wabe } from '..'
-import type { DevWabeTypes } from '../utils/helper'
+import { notEmpty, type DevWabeTypes } from '../utils/helper'
 
 export const initializeRoles = async (wabe: Wabe<DevWabeTypes>) => {
   const roles = wabe.config?.authentication?.roles || []
@@ -20,7 +20,7 @@ export const initializeRoles = async (wabe: Wabe<DevWabeTypes>) => {
     },
   })
 
-  const alreadyCreatedRoles = res.map((role) => role.name)
+  const alreadyCreatedRoles = res.map((role) => role?.name).filter(notEmpty)
 
   const objectsToCreate = roles
     .filter((role) => !alreadyCreatedRoles.includes(role))

--- a/packages/wabe/src/database/adapters/MongoAdapter.test.ts
+++ b/packages/wabe/src/database/adapters/MongoAdapter.test.ts
@@ -55,6 +55,88 @@ describe('Mongo adapter', () => {
       )
   })
 
+  it('should only return id on createObject if fields is empty', async () => {
+    const res = await mongoAdapter.createObject({
+      className: 'User',
+      data: {
+        name: 'John',
+        age: 20,
+      },
+      context,
+      fields: [],
+    })
+
+    expect(ObjectId.isValid(res?.id || '')).toBeTrue()
+    expect(res).toEqual({ id: expect.any(String) })
+  })
+
+  it('should only return an array of id on createObjects if fields is empty', async () => {
+    const res = await mongoAdapter.createObjects({
+      className: 'User',
+      data: [
+        {
+          name: 'John',
+          age: 20,
+        },
+      ],
+      context,
+      fields: [],
+    })
+
+    expect(ObjectId.isValid(res[0]?.id || '')).toBeTrue()
+    expect(res).toEqual([{ id: expect.any(String) }])
+  })
+
+  it('should only return id on updateObject if fields is empty', async () => {
+    const insertedObject = await mongoAdapter.createObject({
+      className: 'User',
+      data: {
+        name: 'John',
+        age: 20,
+      },
+      context,
+      fields: ['*'],
+    })
+
+    const res = await mongoAdapter.updateObject({
+      className: 'User',
+      id: insertedObject?.id || '',
+      data: { name: 'Doe' },
+      fields: [],
+      context,
+    })
+
+    expect(ObjectId.isValid(res?.id || '')).toBeTrue()
+    expect(res).toEqual({ id: expect.any(String) })
+  })
+
+  it('should only return an array of id on updateObjects if fields is empty', async () => {
+    await mongoAdapter.createObjects({
+      className: 'User',
+      data: [
+        {
+          name: 'John',
+          age: 20,
+        },
+      ],
+      context,
+      fields: ['*'],
+    })
+
+    const res = await mongoAdapter.updateObjects({
+      className: 'User',
+      where: {
+        name: { equalTo: 'John' },
+      },
+      data: { name: 'Doe' },
+      fields: [],
+      context,
+    })
+
+    expect(ObjectId.isValid(res[0]?.id || '')).toBeTrue()
+    expect(res).toEqual([{ id: expect.any(String) }])
+  })
+
   it("should order the result by the field 'name' in ascending order", async () => {
     await mongoAdapter.createObjects({
       className: 'User',
@@ -252,7 +334,7 @@ describe('Mongo adapter', () => {
           age: 18,
         },
       ],
-      fields: [],
+      fields: ['id'],
       context,
     })
 
@@ -294,7 +376,7 @@ describe('Mongo adapter', () => {
           age: 18,
         },
       ],
-      fields: [],
+      fields: ['id'],
       context,
     })
 
@@ -338,7 +420,7 @@ describe('Mongo adapter', () => {
           age: 18,
         },
       ],
-      fields: [],
+      fields: ['id'],
       context,
     })
 
@@ -378,7 +460,7 @@ describe('Mongo adapter', () => {
           age: 18,
         },
       ],
-      fields: [],
+      fields: ['id'],
       context,
     })
 
@@ -407,7 +489,7 @@ describe('Mongo adapter', () => {
           age: 18,
         },
       ],
-      fields: [],
+      fields: ['id'],
       context,
     })
 
@@ -436,7 +518,7 @@ describe('Mongo adapter', () => {
           age: 18,
         },
       ],
-      fields: [],
+      fields: ['id'],
       context,
     })
 
@@ -465,7 +547,7 @@ describe('Mongo adapter', () => {
           age: 18,
         },
       ],
-      fields: [],
+      fields: ['id'],
       context,
     })
 
@@ -509,24 +591,6 @@ describe('Mongo adapter', () => {
     )
   })
 
-  it('should return id if an empty fields is specified', async () => {
-    const insertedObjects = await mongoAdapter.createObjects({
-      className: 'User',
-      data: [
-        {
-          name: 'Lucas',
-          age: 20,
-        },
-      ],
-      fields: [],
-      context,
-    })
-
-    if (!insertedObjects) fail()
-
-    expect(insertedObjects[0]?.id).toBeDefined()
-  })
-
   it('should always return id', async () => {
     const insertedObjects = await mongoAdapter.createObjects({
       className: 'User',
@@ -537,7 +601,7 @@ describe('Mongo adapter', () => {
         },
       ],
       context,
-      fields: ['age'],
+      fields: ['age', 'id'],
     })
 
     if (!insertedObjects) fail
@@ -918,7 +982,7 @@ describe('Mongo adapter', () => {
     const field = await mongoAdapter.getObject({
       className: 'User',
       id: id.toString(),
-      fields: ['name'],
+      fields: ['name', 'id'],
       context,
     })
 

--- a/packages/wabe/src/database/adapters/MongoAdapter.test.ts
+++ b/packages/wabe/src/database/adapters/MongoAdapter.test.ts
@@ -10,7 +10,12 @@ import {
 import { fail } from 'node:assert'
 import { ObjectId } from 'mongodb'
 import type { Wabe } from '../..'
-import { type DevWabeTypes, closeTests, setupTests } from '../../utils/helper'
+import {
+  type DevWabeTypes,
+  closeTests,
+  notEmpty,
+  setupTests,
+} from '../../utils/helper'
 import { type MongoAdapter, buildMongoWhereQuery } from './MongoAdapter'
 import type { WabeContext } from '../../server/interface'
 
@@ -76,7 +81,7 @@ describe('Mongo adapter', () => {
       context,
     })
 
-    expect(res.map((user) => user.name)).toEqual(['A', 'B'])
+    expect(res.map((user) => user?.name)).toEqual(['A', 'B'])
   })
 
   it("should order the result by the field 'name' in descending order", async () => {
@@ -105,7 +110,7 @@ describe('Mongo adapter', () => {
       context,
     })
 
-    expect(res.map((user) => user.name)).toEqual(['B', 'A'])
+    expect(res.map((user) => user?.name)).toEqual(['B', 'A'])
   })
 
   it("should order the result by the field 'age' and 'name' in descending order", async () => {
@@ -135,7 +140,7 @@ describe('Mongo adapter', () => {
       context,
     })
 
-    expect(res.map((user) => user.name)).toEqual(['B', 'A'])
+    expect(res.map((user) => user?.name)).toEqual(['B', 'A'])
   })
 
   it('should count all elements corresponds to where condition in collection', async () => {
@@ -257,7 +262,7 @@ describe('Mongo adapter', () => {
         where: {
           name: { equalTo: 'InvalidName' },
         },
-        id: insertedObjects[0].id,
+        id: insertedObjects[0]?.id || '',
         context,
         fields: ['*'],
       }),
@@ -268,12 +273,12 @@ describe('Mongo adapter', () => {
       where: {
         name: { equalTo: 'Lucas' },
       },
-      id: insertedObjects[0].id,
+      id: insertedObjects[0]?.id || '',
       context,
       fields: ['*'],
     })
 
-    expect(res.name).toEqual('Lucas')
+    expect(res?.name).toEqual('Lucas')
   })
 
   it('should support where on updateObject for additional check (acl for example)', async () => {
@@ -299,7 +304,7 @@ describe('Mongo adapter', () => {
         where: {
           name: { equalTo: 'InvalidName' },
         },
-        id: insertedObjects[0].id,
+        id: insertedObjects[0]?.id || '',
         context,
         data: { name: 'Lucas2' },
         fields: ['*'],
@@ -311,13 +316,13 @@ describe('Mongo adapter', () => {
       where: {
         name: { equalTo: 'Lucas' },
       },
-      id: insertedObjects[0].id,
+      id: insertedObjects[0]?.id || '',
       context,
       data: { name: 'Lucas2' },
       fields: ['*'],
     })
 
-    expect(res.name).toEqual('Lucas2')
+    expect(res?.name).toEqual('Lucas2')
   })
 
   it('should support where on delete for additional check (acl for example)', async () => {
@@ -343,7 +348,7 @@ describe('Mongo adapter', () => {
         where: {
           name: { equalTo: 'InvalidName' },
         },
-        id: insertedObjects[0].id,
+        id: insertedObjects[0]?.id || '',
         context,
         fields: ['*'],
       }),
@@ -354,7 +359,7 @@ describe('Mongo adapter', () => {
       where: {
         name: { equalTo: 'Lucas' },
       },
-      id: insertedObjects[0].id,
+      id: insertedObjects[0]?.id || '',
       context,
       fields: ['*'],
     })
@@ -380,7 +385,7 @@ describe('Mongo adapter', () => {
     const res = await mongoAdapter.getObjects({
       className: 'User',
       where: {
-        id: { notEqualTo: insertedObjects[0].id },
+        id: { notEqualTo: insertedObjects[0]?.id },
       },
       context,
       fields: ['*'],
@@ -409,7 +414,7 @@ describe('Mongo adapter', () => {
     const res = await mongoAdapter.getObjects({
       className: 'User',
       where: {
-        id: { equalTo: insertedObjects[0].id },
+        id: { equalTo: insertedObjects[0]?.id },
       },
       context,
       fields: ['*'],
@@ -438,7 +443,7 @@ describe('Mongo adapter', () => {
     const res = await mongoAdapter.getObjects({
       className: 'User',
       where: {
-        id: { in: insertedObjects.map((obj) => obj.id) },
+        id: { in: insertedObjects.map((obj) => obj?.id).filter(notEmpty) },
       },
       context,
       fields: ['*'],
@@ -467,7 +472,7 @@ describe('Mongo adapter', () => {
     const res = await mongoAdapter.getObjects({
       className: 'User',
       where: {
-        id: { notIn: insertedObjects.map((obj) => obj.id) },
+        id: { notIn: insertedObjects.map((obj) => obj?.id).filter(notEmpty) },
       },
       context,
       fields: ['*'],
@@ -519,7 +524,7 @@ describe('Mongo adapter', () => {
 
     if (!insertedObjects) fail()
 
-    expect(insertedObjects[0].id).toBeDefined()
+    expect(insertedObjects[0]?.id).toBeDefined()
   })
 
   it('should always return id', async () => {
@@ -537,7 +542,7 @@ describe('Mongo adapter', () => {
 
     if (!insertedObjects) fail
 
-    expect(insertedObjects[0].id).toBeDefined()
+    expect(insertedObjects[0]?.id).toBeDefined()
   })
 
   it('should return id if no fields is specified', async () => {
@@ -555,7 +560,7 @@ describe('Mongo adapter', () => {
 
     if (!insertedObjects) fail()
 
-    expect(insertedObjects[0].id).toBeDefined()
+    expect(insertedObjects[0]?.id).toBeDefined()
   })
 
   it('should getObjects using id and not _id', async () => {
@@ -582,7 +587,7 @@ describe('Mongo adapter', () => {
       where: {
         id: {
           equalTo: ObjectId.createFromHexString(
-            insertedObjects[0].id,
+            insertedObjects[0]?.id || '',
           ).toString(),
         },
       },
@@ -631,8 +636,8 @@ describe('Mongo adapter', () => {
     })
 
     expect(res.length).toEqual(2)
-    expect(res[0].name).toEqual('John2')
-    expect(res[1].name).toEqual('John3')
+    expect(res[0]?.name).toEqual('John2')
+    expect(res[1]?.name).toEqual('John3')
   })
 
   it('should get all the objects with limit', async () => {
@@ -805,8 +810,8 @@ describe('Mongo adapter', () => {
     })
 
     expect(res.length).toEqual(2)
-    expect(res[0].name).toEqual('John2')
-    expect(res[1].name).toEqual('John3')
+    expect(res[0]?.name).toEqual('John2')
+    expect(res[1]?.name).toEqual('John3')
 
     await mongoAdapter.deleteObjects({
       className: 'User',
@@ -851,13 +856,13 @@ describe('Mongo adapter', () => {
     })
 
     const res = await mongoAdapter.getObject({
-      id: insertedObject?.id.toString(),
+      id: insertedObject?.id.toString() || '',
       className: 'User',
       fields: ['id'],
       context,
     })
 
-    expect(res?.id).toEqual(insertedObject?.id)
+    expect(res?.id).toEqual(insertedObject?.id || '')
   })
 
   it('should get all fields when * is specified', async () => {
@@ -1639,8 +1644,10 @@ describe('Mongo adapter', () => {
     })
 
     expect(res.length).toEqual(1)
-    expect(res[0].authentication?.emailPassword?.email).toEqual('email@test.fr')
-    expect(res[0].authentication?.emailPassword?.password).toEqual('password')
+    expect(res[0]?.authentication?.emailPassword?.email).toEqual(
+      'email@test.fr',
+    )
+    expect(res[0]?.authentication?.emailPassword?.password).toEqual('password')
   })
 
   it('should request sub object in object with selection fields', async () => {
@@ -1673,7 +1680,9 @@ describe('Mongo adapter', () => {
     })
 
     expect(res.length).toEqual(1)
-    expect(res[0].authentication?.emailPassword?.email).toEqual('email@test.fr')
-    expect(res[0].authentication?.emailPassword?.password).toBeUndefined()
+    expect(res[0]?.authentication?.emailPassword?.email).toEqual(
+      'email@test.fr',
+    )
+    expect(res[0]?.authentication?.emailPassword?.password).toBeUndefined()
   })
 })

--- a/packages/wabe/src/database/adapters/MongoAdapter.ts
+++ b/packages/wabe/src/database/adapters/MongoAdapter.ts
@@ -429,7 +429,7 @@ export class MongoAdapter<T extends WabeTypes> implements DatabaseAdapter<T> {
     })
 
     const orStatement = objectsBeforeUpdate.map((object) => ({
-      id: { equalTo: ObjectId.createFromHexString(object.id) },
+      id: { equalTo: ObjectId.createFromHexString(object?.id) },
     }))
 
     const objects = await context.wabe.controllers.database.getObjects({

--- a/packages/wabe/src/database/adapters/MongoAdapter.ts
+++ b/packages/wabe/src/database/adapters/MongoAdapter.ts
@@ -313,14 +313,15 @@ export class MongoAdapter<T extends WabeTypes> implements DatabaseAdapter<T> {
 
     const res = await collection.insertOne(data, {})
 
-    const object = await context.wabe.controllers.database.getObject({
+    // @ts-expect-error
+    if (fields.length === 0) return { id: res.insertedId.toString() }
+
+    return context.wabe.controllers.database.getObject({
       className,
       id: res.insertedId.toString(),
       context,
       fields,
     })
-
-    return object
   }
 
   async createObjects<
@@ -344,7 +345,11 @@ export class MongoAdapter<T extends WabeTypes> implements DatabaseAdapter<T> {
       id: { equalTo: value },
     }))
 
-    const allObjects = await context.wabe.controllers.database.getObjects({
+    if (fields.length === 0)
+      // @ts-expect-error
+      return Object.values(res.insertedIds).map((id) => ({ id: id.toString() }))
+
+    return context.wabe.controllers.database.getObjects({
       className,
       where: { OR: orStatement } as WhereType<T, K>,
       fields,
@@ -353,8 +358,6 @@ export class MongoAdapter<T extends WabeTypes> implements DatabaseAdapter<T> {
       context,
       order,
     })
-
-    return allObjects
   }
 
   async updateObject<
@@ -383,14 +386,15 @@ export class MongoAdapter<T extends WabeTypes> implements DatabaseAdapter<T> {
 
     if (res.matchedCount === 0) throw new Error('Object not found')
 
-    const object = await context.wabe.controllers.database.getObject({
+    // @ts-expect-error
+    if (fields.length === 0) return { id }
+
+    return context.wabe.controllers.database.getObject({
       className,
       context,
       fields,
       id,
     })
-
-    return object
   }
 
   async updateObjects<
@@ -418,11 +422,15 @@ export class MongoAdapter<T extends WabeTypes> implements DatabaseAdapter<T> {
         fields: ['id'],
         offset,
         first,
-        context,
+        context: {
+          ...context,
+          // Root because we need the id at least for hook
+          isRoot: true,
+        },
         order,
       })
 
-    if (objectsBeforeUpdate.length === 0) throw new Error('Object not found')
+    if (objectsBeforeUpdate.length === 0) return []
 
     await collection.updateMany(whereBuilded, {
       $set: data,
@@ -432,7 +440,13 @@ export class MongoAdapter<T extends WabeTypes> implements DatabaseAdapter<T> {
       id: { equalTo: ObjectId.createFromHexString(object?.id) },
     }))
 
-    const objects = await context.wabe.controllers.database.getObjects({
+    if (fields.length === 0)
+      // @ts-expect-error
+      return Object.values(objectsBeforeUpdate).map((object) => ({
+        id: object?.id,
+      }))
+
+    return context.wabe.controllers.database.getObjects({
       className,
       where: {
         OR: orStatement,
@@ -442,8 +456,6 @@ export class MongoAdapter<T extends WabeTypes> implements DatabaseAdapter<T> {
       first,
       context,
     })
-
-    return objects
   }
 
   async deleteObject<K extends keyof T['types'], U extends keyof T['types'][K]>(

--- a/packages/wabe/src/database/adapters/adaptersInterface.ts
+++ b/packages/wabe/src/database/adapters/adaptersInterface.ts
@@ -193,7 +193,7 @@ export type OutputType<
   T extends WabeTypes,
   K extends keyof T['types'],
   U extends keyof T['types'][K],
-> = Pick<T['types'][K], U> & { id: string }
+> = (Pick<T['types'][K], U> & { id: string }) | null
 
 export interface DatabaseAdapter<T extends WabeTypes> {
   connect(): Promise<any>

--- a/packages/wabe/src/database/controllers/DatabaseController.ts
+++ b/packages/wabe/src/database/controllers/DatabaseController.ts
@@ -261,7 +261,7 @@ export class DatabaseController<T extends WabeTypes> {
         // If we don't found any object we just execute the query with the default where
         // Without any transformation for pointer or relation
         [typedWhereKey]: {
-          in: objects.map((object) => object.id),
+          in: objects.map((object) => object?.id).filter(notEmpty),
         },
       }
     }, Promise.resolve({}))
@@ -580,7 +580,7 @@ export class DatabaseController<T extends WabeTypes> {
         isRoot: true,
       },
       fields,
-      id: object.id,
+      id: res.object.id,
       skipHooks: true,
     })
 
@@ -634,7 +634,7 @@ export class DatabaseController<T extends WabeTypes> {
       order,
     })
 
-    const objectsId = objects.map((object) => object.id)
+    const objectsId = objects.map((object) => object?.id).filter(notEmpty)
 
     const res = await Promise.all(
       hooks.map((hook) =>
@@ -644,6 +644,8 @@ export class DatabaseController<T extends WabeTypes> {
         }),
       ),
     )
+
+    if (fields.length === 0) return []
 
     // If there is no hook to run it returns undefined object
     if (res.filter((hook) => hook.objects.length > 0).length === 0)
@@ -702,13 +704,15 @@ export class DatabaseController<T extends WabeTypes> {
       object,
     })
 
+    if (fields.length === 0) return null
+
     if (!res.object) return object
 
     const objectToReturn = await this.getObject({
       className,
       context,
       fields,
-      id: object.id,
+      id: res.object.id,
       skipHooks: true,
     })
 
@@ -764,12 +768,14 @@ export class DatabaseController<T extends WabeTypes> {
       order,
     })
 
-    const objectsId = objects.map((object) => object.id)
+    const objectsId = objects.map((object) => object?.id).filter(notEmpty)
 
     const res = await hook.runOnMultipleObjects({
       operationType: OperationType.AfterUpdate,
       objects,
     })
+
+    if (fields.length === 0) return []
 
     // If there is no hook to run it returns undefined object
     if (res.objects.length === 0) return objects
@@ -829,6 +835,8 @@ export class DatabaseController<T extends WabeTypes> {
       operationType: OperationType.AfterDelete,
       object,
     })
+
+    if (fields.length === 0) return null
 
     return objectBeforeDelete
   }
@@ -894,6 +902,8 @@ export class DatabaseController<T extends WabeTypes> {
       operationType: OperationType.AfterDelete,
       objects,
     })
+
+    if (fields.length === 0) return []
 
     return objectsBeforeDelete
   }

--- a/packages/wabe/src/database/controllers/DatabaseController.ts
+++ b/packages/wabe/src/database/controllers/DatabaseController.ts
@@ -811,12 +811,15 @@ export class DatabaseController<T extends WabeTypes> {
 
     const whereWithACLCondition = this._buildWhereWithACL({}, context, 'write')
 
-    const objectBeforeDelete = await this.getObject({
-      className,
-      fields,
-      id,
-      context,
-    })
+    let objectBeforeDelete = null
+
+    if (fields.length > 0)
+      objectBeforeDelete = await this.getObject({
+        className,
+        fields,
+        id,
+        context,
+      })
 
     const { object } = await hook.runOnSingleObject({
       operationType: OperationType.BeforeDelete,
@@ -835,8 +838,6 @@ export class DatabaseController<T extends WabeTypes> {
       operationType: OperationType.AfterDelete,
       object,
     })
-
-    if (fields.length === 0) return null
 
     return objectBeforeDelete
   }
@@ -871,17 +872,20 @@ export class DatabaseController<T extends WabeTypes> {
       'write',
     )
 
-    const objectsBeforeDelete = await this.getObjects({
-      className,
-      where,
-      fields,
-      context,
-      first,
-      offset,
-      order,
-    })
+    let objectsBeforeDelete: OutputType<T, K, W>[] = []
 
-    if (objectsBeforeDelete.length === 0) return objectsBeforeDelete
+    if (fields.length > 0)
+      objectsBeforeDelete = await this.getObjects({
+        className,
+        where,
+        fields,
+        context,
+        first,
+        offset,
+        order,
+      })
+
+    if (objectsBeforeDelete.length === 0) return []
 
     const { objects } = await hook.runOnMultipleObjects({
       operationType: OperationType.BeforeDelete,
@@ -902,8 +906,6 @@ export class DatabaseController<T extends WabeTypes> {
       operationType: OperationType.AfterDelete,
       objects,
     })
-
-    if (fields.length === 0) return []
 
     return objectsBeforeDelete
   }

--- a/packages/wabe/src/database/controllers/DatabaseController.ts
+++ b/packages/wabe/src/database/controllers/DatabaseController.ts
@@ -604,6 +604,8 @@ export class DatabaseController<T extends WabeTypes> {
       object,
     })
 
+    if (fields.length === 0) return null
+
     // If there is no hook to run it returns undefined object
     if (!res.object) return object
 

--- a/packages/wabe/src/database/controllers/DatabaseController.ts
+++ b/packages/wabe/src/database/controllers/DatabaseController.ts
@@ -634,8 +634,6 @@ export class DatabaseController<T extends WabeTypes> {
       order,
     })
 
-    const objectsId = objects.map((object) => object?.id).filter(notEmpty)
-
     const res = await Promise.all(
       hooks.map((hook) =>
         hook.runOnMultipleObjects({
@@ -650,6 +648,8 @@ export class DatabaseController<T extends WabeTypes> {
     // If there is no hook to run it returns undefined object
     if (res.filter((hook) => hook.objects.length > 0).length === 0)
       return objects
+
+    const objectsId = objects.map((object) => object?.id).filter(notEmpty)
 
     const objectsToReturn = await this.getObjects({
       className,
@@ -884,8 +884,6 @@ export class DatabaseController<T extends WabeTypes> {
         offset,
         order,
       })
-
-    if (objectsBeforeDelete.length === 0) return []
 
     const { objects } = await hook.runOnMultipleObjects({
       operationType: OperationType.BeforeDelete,

--- a/packages/wabe/src/database/index.test.ts
+++ b/packages/wabe/src/database/index.test.ts
@@ -99,7 +99,7 @@ describe('Database', () => {
     spyGetObjects.mockClear()
   })
 
-  it.only('should return undefined on createObject when no fields are provided', async () => {
+  it('should return null on createObject when no fields are provided', async () => {
     const res = await wabe.controllers.database.createObject({
       className: 'User',
       context,
@@ -107,7 +107,92 @@ describe('Database', () => {
       fields: [],
     })
 
-    expect(res).toBeUndefined()
+    expect(res).toBeNull()
+  })
+
+  it('should return empty array on createObjects when no fields are provided', async () => {
+    const res = await wabe.controllers.database.createObjects({
+      className: 'User',
+      context,
+      data: [{ name: 'Lucas' }],
+      fields: [],
+    })
+
+    expect(res).toBeEmpty()
+  })
+
+  it('should return null on updateObject when no fields are provided', async () => {
+    const createdObject = await wabe.controllers.database.createObject({
+      className: 'User',
+      context,
+      data: { name: 'Lucas' },
+      fields: ['id'],
+    })
+
+    const res = await wabe.controllers.database.updateObject({
+      className: 'User',
+      context,
+      data: { name: 'Lucas' },
+      fields: [],
+      id: createdObject?.id || '',
+    })
+
+    expect(res).toBeNull()
+  })
+
+  it('should return empty array on updateObjects when no fields are provided', async () => {
+    await wabe.controllers.database.createObject({
+      className: 'User',
+      context,
+      data: { name: 'Lucas' },
+      fields: ['id'],
+    })
+
+    const res = await wabe.controllers.database.updateObjects({
+      className: 'User',
+      context,
+      data: { name: 'Lucas2' },
+      fields: [],
+      where: { name: { equalTo: 'Lucas' } },
+    })
+
+    expect(res).toBeEmpty()
+  })
+
+  it('should return null on deleteObject when no fields are provided', async () => {
+    const createdObject = await wabe.controllers.database.createObject({
+      className: 'User',
+      context,
+      data: { name: 'Lucas' },
+      fields: ['id'],
+    })
+
+    const res = await wabe.controllers.database.deleteObject({
+      className: 'User',
+      context,
+      fields: [],
+      id: createdObject?.id || '',
+    })
+
+    expect(res).toBeNull()
+  })
+
+  it('should return empty array on deleteObjects when no fields are provided', async () => {
+    await wabe.controllers.database.createObject({
+      className: 'User',
+      context,
+      data: { name: 'Lucas' },
+      fields: ['id'],
+    })
+
+    const res = await wabe.controllers.database.deleteObjects({
+      className: 'User',
+      context,
+      fields: [],
+      where: { name: { equalTo: 'Lucas' } },
+    })
+
+    expect(res).toBeEmpty()
   })
 
   it("should return all elements of a class when the object doesn't have ACL but the user is connected", async () => {
@@ -175,8 +260,8 @@ describe('Database', () => {
       order: { name: 'ASC' },
     })
 
-    expect(res[0].name).toBe('test1')
-    expect(res[1].name).toBe('test2')
+    expect(res[0]?.name).toBe('test1')
+    expect(res[1]?.name).toBe('test2')
   })
 
   it('should create object with subobject (hooks default call authentication before create user)', async () => {
@@ -197,7 +282,7 @@ describe('Database', () => {
       },
     })
 
-    expect(res.authentication?.google).toEqual({
+    expect(res?.authentication?.google).toEqual({
       email: 'email@test.fr',
       verifiedEmail: true,
       idToken: 'idToken',
@@ -233,7 +318,7 @@ describe('Database', () => {
   it('should not computeObject in runOnSingleObject if there is no hooks to execute on updateObject', async () => {
     wabe.config.hooks = []
 
-    const { id } = await wabe.controllers.database.createObject({
+    const res = await wabe.controllers.database.createObject({
       className: 'User',
       context,
       data: { name: 'Lucas' },
@@ -248,7 +333,7 @@ describe('Database', () => {
       // @ts-expect-error
       data: [{ name: 'Lucas' }],
       fields: ['id'],
-      id,
+      id: res?.id || '',
     })
 
     expect(spyGetObject).toHaveBeenCalledTimes(1)
@@ -257,7 +342,7 @@ describe('Database', () => {
   it('should not computeObject in runOnMultipleObject if there is no hooks to execute on updateObjects', async () => {
     wabe.config.hooks = []
 
-    const { id } = await wabe.controllers.database.createObject({
+    const res = await wabe.controllers.database.createObject({
       className: 'User',
       context,
       data: { name: 'Lucas' },
@@ -271,7 +356,7 @@ describe('Database', () => {
       context,
       data: { name: 'Lucas' },
       fields: ['id'],
-      where: { id: { equalTo: id } },
+      where: { id: { equalTo: res?.id || '' } },
     })
 
     // Mongo adapter call 2 times getObjects in updateObjects
@@ -281,7 +366,7 @@ describe('Database', () => {
   it('should not computeObject in runOnSingleObject if there is no hooks to execute on updateObject', async () => {
     wabe.config.hooks = []
 
-    const { id } = await wabe.controllers.database.createObject({
+    const res = await wabe.controllers.database.createObject({
       className: 'User',
       context,
       data: { name: 'Lucas' },
@@ -294,7 +379,7 @@ describe('Database', () => {
       className: 'User',
       context,
       fields: ['id'],
-      id,
+      id: res?.id || '',
     })
 
     expect(spyGetObject).toHaveBeenCalledTimes(1)
@@ -303,7 +388,7 @@ describe('Database', () => {
   it('should not computeObject in runOnMultipleObject if there is no hooks to execute on updateObjects', async () => {
     wabe.config.hooks = []
 
-    const { id } = await wabe.controllers.database.createObject({
+    const res = await wabe.controllers.database.createObject({
       className: 'User',
       context,
       data: { name: 'Lucas' },
@@ -316,7 +401,7 @@ describe('Database', () => {
       className: 'User',
       context,
       fields: ['id'],
-      where: { id: { equalTo: id } },
+      where: { id: { equalTo: res?.id || '' } },
     })
 
     expect(spyGetObjects).toHaveBeenCalledTimes(1)
@@ -344,7 +429,7 @@ describe('Database', () => {
       fields: ['age'],
     })
 
-    expect(res.age).toEqual(21)
+    expect(res?.age).toEqual(21)
 
     expect(mockUpdateObject).toHaveBeenCalledTimes(1)
   })
@@ -371,7 +456,7 @@ describe('Database', () => {
       fields: ['age'],
     })
 
-    expect(res[0].age).toEqual(21)
+    expect(res[0]?.age).toEqual(21)
 
     expect(mockUpdateObject).toHaveBeenCalledTimes(1)
   })
@@ -438,10 +523,10 @@ describe('Database', () => {
       context,
       fields: ['name'],
       data: { age: 20 },
-      id: res[0].id,
+      id: res[0]?.id,
     })
 
-    expect(res2.name).toEqual('test')
+    expect(res2?.name).toEqual('test')
 
     expect(mockAfterUpdate).toHaveBeenCalledTimes(1)
   })

--- a/packages/wabe/src/database/index.test.ts
+++ b/packages/wabe/src/database/index.test.ts
@@ -99,6 +99,17 @@ describe('Database', () => {
     spyGetObjects.mockClear()
   })
 
+  it.only('should return undefined on createObject when no fields are provided', async () => {
+    const res = await wabe.controllers.database.createObject({
+      className: 'User',
+      context,
+      data: { name: 'Lucas' },
+      fields: [],
+    })
+
+    expect(res).toBeUndefined()
+  })
+
   it("should return all elements of a class when the object doesn't have ACL but the user is connected", async () => {
     const anonymousClient = getAnonymousClient(context.wabe.config.port)
 

--- a/packages/wabe/src/graphql/pointerAndRelationFunction.ts
+++ b/packages/wabe/src/graphql/pointerAndRelationFunction.ts
@@ -36,7 +36,7 @@ export const createAndLink = async ({
 }) => {
   const classInSchema = getClassFromClassName(className, context.wabe.config)
 
-  const { id } = await context.wabe.controllers.database.createObject({
+  const res = await context.wabe.controllers.database.createObject({
     // @ts-expect-error
     className: classInSchema.fields[fieldName].class,
     data: createAndLink,
@@ -44,7 +44,7 @@ export const createAndLink = async ({
     context,
   })
 
-  return id
+  return res?.id
 }
 
 export const createAndAdd = async ({
@@ -102,7 +102,7 @@ export const add = async ({
       context,
     })
 
-    return [...(currentValue[fieldName] || []), ...add]
+    return [...(currentValue?.[fieldName] || []), ...add]
   }
 
   // For update many we need to get all objects that match the where and add the new value
@@ -163,7 +163,7 @@ export const remove = async ({
       context,
     })
 
-    const olderValues = currentValue[fieldName] || []
+    const olderValues = currentValue?.[fieldName] || []
 
     return olderValues.filter((olderValue: any) => !remove.includes(olderValue))
   }

--- a/packages/wabe/src/hooks/searchableFields.test.ts
+++ b/packages/wabe/src/hooks/searchableFields.test.ts
@@ -48,7 +48,7 @@ describe('searchablesFields', () => {
       },
     })
 
-    expect(res[0].search).toEqual([
+    expect(res[0]?.search).toEqual([
       'a',
       'ad',
       'adm',

--- a/packages/wabe/src/hooks/setupAcl.ts
+++ b/packages/wabe/src/hooks/setupAcl.ts
@@ -1,4 +1,5 @@
 import type { ACLProperties } from '../schema'
+import { notEmpty } from '../utils/helper'
 import type { HookObject } from './HookObject'
 
 const isReadTrueOnUser = (aclObject: ACLProperties) =>
@@ -68,8 +69,8 @@ const setAcl = async ({
 
   const allRolesIdsWithoutDuplicate = [
     ...new Set([
-      ...idOfAllReadRoles.map((role) => role.id),
-      ...idOfAllWriteRoles.map((role) => role.id),
+      ...idOfAllReadRoles.map((role) => role?.id).filter(notEmpty),
+      ...idOfAllWriteRoles.map((role) => role?.id).filter(notEmpty),
     ]),
   ]
 
@@ -86,8 +87,8 @@ const setAcl = async ({
     roles: [
       ...allRolesIdsWithoutDuplicate.map((roleId) => ({
         roleId,
-        read: idOfAllReadRoles.some((role) => role.id === roleId),
-        write: idOfAllWriteRoles.some((role) => role.id === roleId),
+        read: idOfAllReadRoles.some((role) => role?.id === roleId),
+        write: idOfAllWriteRoles.some((role) => role?.id === roleId),
       })),
     ],
   }

--- a/packages/wabe/src/schema/resolvers/resetPassword.ts
+++ b/packages/wabe/src/schema/resolvers/resetPassword.ts
@@ -26,7 +26,9 @@ export const resetPasswordResolver = async (
   // We return true if the user doesn't exist to avoid leaking that the user exists or not
   if (user.length === 0) return true
 
-  const userId = user[0].id
+  const userId = user[0]?.id
+
+  if (!userId) return false
 
   const otpClass = new OTP(context.wabe.config.rootKey)
 

--- a/packages/wabe/src/schema/resolvers/sendOtpCode.ts
+++ b/packages/wabe/src/schema/resolvers/sendOtpCode.ts
@@ -31,7 +31,9 @@ export const sendOtpCodeResolver = async (
   // We return true if the user doesn't exist to avoid leaking that the user exists or not
   if (user.length === 0) return true
 
-  const userId = user[0].id
+  const userId = user[0]?.id
+
+  if (!userId) return false
 
   const otpClass = new OTP(context.wabe.config.rootKey)
 


### PR DESCRIPTION
We should only read on CUD operations if the `fields` field is not empty.