### PR TITLE
feat(wabe): allow to mutate an object without return any data

### DIFF
--- a/packages/wabe/generated/schema.graphql
+++ b/packages/wabe/generated/schema.graphql
@@ -1266,7 +1266,7 @@ type Mutation {
 
 type CreateUserPayload {
   user: User
-  clientMutationId: String
+  ok: Boolean
 }
 
 input CreateUserInput {
@@ -1282,7 +1282,7 @@ input CreateUsersInput {
 
 type UpdateUserPayload {
   user: User
-  clientMutationId: String
+  ok: Boolean
 }
 
 input UpdateUserInput {
@@ -1350,7 +1350,7 @@ input UpdateUsersInput {
 
 type DeleteUserPayload {
   user: User
-  clientMutationId: String
+  ok: Boolean
 }
 
 input DeleteUserInput {
@@ -1364,7 +1364,7 @@ input DeleteUsersInput {
 
 type CreatePostPayload {
   post: Post
-  clientMutationId: String
+  ok: Boolean
 }
 
 input CreatePostInput {
@@ -1380,7 +1380,7 @@ input CreatePostsInput {
 
 type UpdatePostPayload {
   post: Post
-  clientMutationId: String
+  ok: Boolean
 }
 
 input UpdatePostInput {
@@ -1424,7 +1424,7 @@ input UpdatePostsInput {
 
 type DeletePostPayload {
   post: Post
-  clientMutationId: String
+  ok: Boolean
 }
 
 input DeletePostInput {
@@ -1438,7 +1438,7 @@ input DeletePostsInput {
 
 type Create_SessionPayload {
   _session: _Session
-  clientMutationId: String
+  ok: Boolean
 }
 
 input Create_SessionInput {
@@ -1454,7 +1454,7 @@ input Create_SessionsInput {
 
 type Update_SessionPayload {
   _session: _Session
-  clientMutationId: String
+  ok: Boolean
 }
 
 input Update_SessionInput {
@@ -1501,7 +1501,7 @@ input Update_SessionsInput {
 
 type Delete_SessionPayload {
   _session: _Session
-  clientMutationId: String
+  ok: Boolean
 }
 
 input Delete_SessionInput {
@@ -1515,7 +1515,7 @@ input Delete_SessionsInput {
 
 type CreateRolePayload {
   role: Role
-  clientMutationId: String
+  ok: Boolean
 }
 
 input CreateRoleInput {
@@ -1531,7 +1531,7 @@ input CreateRolesInput {
 
 type UpdateRolePayload {
   role: Role
-  clientMutationId: String
+  ok: Boolean
 }
 
 input UpdateRoleInput {
@@ -1575,7 +1575,7 @@ input UpdateRolesInput {
 
 type DeleteRolePayload {
   role: Role
-  clientMutationId: String
+  ok: Boolean
 }
 
 input DeleteRoleInput {
@@ -1589,7 +1589,7 @@ input DeleteRolesInput {
 
 type CreatePaymentPayload {
   payment: Payment
-  clientMutationId: String
+  ok: Boolean
 }
 
 input CreatePaymentInput {
@@ -1605,7 +1605,7 @@ input CreatePaymentsInput {
 
 type UpdatePaymentPayload {
   payment: Payment
-  clientMutationId: String
+  ok: Boolean
 }
 
 input UpdatePaymentInput {
@@ -1650,7 +1650,7 @@ input UpdatePaymentsInput {
 
 type DeletePaymentPayload {
   payment: Payment
-  clientMutationId: String
+  ok: Boolean
 }
 
 input DeletePaymentInput {
@@ -1664,7 +1664,7 @@ input DeletePaymentsInput {
 
 type Create_InternalConfigPayload {
   _internalConfig: _InternalConfig
-  clientMutationId: String
+  ok: Boolean
 }
 
 input Create_InternalConfigInput {
@@ -1680,7 +1680,7 @@ input Create_InternalConfigsInput {
 
 type Update_InternalConfigPayload {
   _internalConfig: _InternalConfig
-  clientMutationId: String
+  ok: Boolean
 }
 
 input Update_InternalConfigInput {
@@ -1725,7 +1725,7 @@ input Update_InternalConfigsInput {
 
 type Delete_InternalConfigPayload {
   _internalConfig: _InternalConfig
-  clientMutationId: String
+  ok: Boolean
 }
 
 input Delete_InternalConfigInput {

--- a/packages/wabe/generated/wabe.ts
+++ b/packages/wabe/generated/wabe.ts
@@ -1477,7 +1477,7 @@ export type MutationVerifyChallengeArgs = {
 
 export type CreateUserPayload = {
   user?: User;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type CreateUserInput = {
@@ -1493,7 +1493,7 @@ export type CreateUsersInput = {
 
 export type UpdateUserPayload = {
   user?: User;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type UpdateUserInput = {
@@ -1560,7 +1560,7 @@ export type UpdateUsersInput = {
 
 export type DeleteUserPayload = {
   user?: User;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type DeleteUserInput = {
@@ -1574,7 +1574,7 @@ export type DeleteUsersInput = {
 
 export type CreatePostPayload = {
   post?: Post;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type CreatePostInput = {
@@ -1590,7 +1590,7 @@ export type CreatePostsInput = {
 
 export type UpdatePostPayload = {
   post?: Post;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type UpdatePostInput = {
@@ -1634,7 +1634,7 @@ export type UpdatePostsInput = {
 
 export type DeletePostPayload = {
   post?: Post;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type DeletePostInput = {
@@ -1648,7 +1648,7 @@ export type DeletePostsInput = {
 
 export type Create_SessionPayload = {
   _session?: _Session;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type Create_SessionInput = {
@@ -1664,7 +1664,7 @@ export type Create_SessionsInput = {
 
 export type Update_SessionPayload = {
   _session?: _Session;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type Update_SessionInput = {
@@ -1711,7 +1711,7 @@ export type Update_SessionsInput = {
 
 export type Delete_SessionPayload = {
   _session?: _Session;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type Delete_SessionInput = {
@@ -1725,7 +1725,7 @@ export type Delete_SessionsInput = {
 
 export type CreateRolePayload = {
   role?: Role;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type CreateRoleInput = {
@@ -1741,7 +1741,7 @@ export type CreateRolesInput = {
 
 export type UpdateRolePayload = {
   role?: Role;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type UpdateRoleInput = {
@@ -1785,7 +1785,7 @@ export type UpdateRolesInput = {
 
 export type DeleteRolePayload = {
   role?: Role;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type DeleteRoleInput = {
@@ -1799,7 +1799,7 @@ export type DeleteRolesInput = {
 
 export type CreatePaymentPayload = {
   payment?: Payment;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type CreatePaymentInput = {
@@ -1815,7 +1815,7 @@ export type CreatePaymentsInput = {
 
 export type UpdatePaymentPayload = {
   payment?: Payment;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type UpdatePaymentInput = {
@@ -1860,7 +1860,7 @@ export type UpdatePaymentsInput = {
 
 export type DeletePaymentPayload = {
   payment?: Payment;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type DeletePaymentInput = {
@@ -1874,7 +1874,7 @@ export type DeletePaymentsInput = {
 
 export type Create_InternalConfigPayload = {
   _internalConfig?: _InternalConfig;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type Create_InternalConfigInput = {
@@ -1890,7 +1890,7 @@ export type Create_InternalConfigsInput = {
 
 export type Update_InternalConfigPayload = {
   _internalConfig?: _InternalConfig;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type Update_InternalConfigInput = {
@@ -1935,7 +1935,7 @@ export type Update_InternalConfigsInput = {
 
 export type Delete_InternalConfigPayload = {
   _internalConfig?: _InternalConfig;
-  clientMutationId?: Scalars['String']['output'];
+  ok?: Scalars['Boolean']['output'];
 };
 
 export type Delete_InternalConfigInput = {

--- a/packages/wabe/src/graphql/GraphQLSchema.ts
+++ b/packages/wabe/src/graphql/GraphQLSchema.ts
@@ -9,7 +9,6 @@ import {
   GraphQLObjectType,
   type GraphQLOutputType,
   GraphQLScalarType,
-  GraphQLString,
   GraphQLBoolean,
 } from 'graphql'
 import { pluralize } from 'wabe-pluralize'
@@ -712,7 +711,7 @@ export class GraphQLSchema {
       name: `Create${className}Payload`,
       fields: () => ({
         [classNameWithFirstLetterLowerCase]: { type: object },
-        clientMutationId: { type: GraphQLString },
+        ok: { type: GraphQLBoolean },
       }),
     })
 
@@ -739,7 +738,7 @@ export class GraphQLSchema {
       name: `Update${className}Payload`,
       fields: () => ({
         [classNameWithFirstLetterLowerCase]: { type: object },
-        clientMutationId: { type: GraphQLString },
+        ok: { type: GraphQLBoolean },
       }),
     })
 
@@ -766,7 +765,7 @@ export class GraphQLSchema {
       name: `Delete${className}Payload`,
       fields: () => ({
         [classNameWithFirstLetterLowerCase]: { type: object },
-        clientMutationId: { type: GraphQLString },
+        ok: { type: GraphQLBoolean },
       }),
     })
 


### PR DESCRIPTION
We need to be able to create an object but don't return any data, like id. Just add a "ok" field that equal to true if all is good. It avoid to get useless data you don't need for just to match with GraphQL requirement. It also allows to avoid issues when for example anonymous have the permission to create an object but not to read.