### PR TITLE
feat(wabe): improve mongo adapter removing all useless read on database adapter

### DIFF
--- a/packages/wabe/src/database/adapters/adaptersInterface.ts
+++ b/packages/wabe/src/database/adapters/adaptersInterface.ts
@@ -223,25 +223,25 @@ export interface DatabaseAdapter<T extends WabeTypes> {
     K extends keyof T['types'],
     U extends keyof T['types'][K],
     W extends keyof T['types'][K],
-  >(params: CreateObjectOptions<T, K, U, W>): Promise<OutputType<T, K, W>>
+  >(params: CreateObjectOptions<T, K, U, W>): Promise<{ id: string }>
   createObjects<
     K extends keyof T['types'],
     U extends keyof T['types'][K],
     W extends keyof T['types'][K],
     X extends keyof T['types'][K],
-  >(params: CreateObjectsOptions<T, K, U, W, X>): Promise<OutputType<T, K, W>[]>
+  >(params: CreateObjectsOptions<T, K, U, W, X>): Promise<Array<{ id: string }>>
 
   updateObject<
     K extends keyof T['types'],
     U extends keyof T['types'][K],
     W extends keyof T['types'][K],
-  >(params: UpdateObjectOptions<T, K, U, W>): Promise<OutputType<T, K, W>>
+  >(params: UpdateObjectOptions<T, K, U, W>): Promise<{ id: string }>
   updateObjects<
     K extends keyof T['types'],
     U extends keyof T['types'][K],
     W extends keyof T['types'][K],
     X extends keyof T['types'][K],
-  >(params: UpdateObjectsOptions<T, K, U, W, X>): Promise<OutputType<T, K, W>[]>
+  >(params: UpdateObjectsOptions<T, K, U, W, X>): Promise<Array<{ id: string }>>
 
   deleteObject<K extends keyof T['types'], U extends keyof T['types'][K]>(
     params: DeleteObjectOptions<T, K, U>,

--- a/packages/wabe/src/database/controllers/DatabaseController.test.ts
+++ b/packages/wabe/src/database/controllers/DatabaseController.test.ts
@@ -24,7 +24,7 @@ describe('DatabaseController', () => {
   const mockClearDatabase = mock(() => {})
   const mockCount = mock(() => {})
 
-  const mockRunOnSingleObject = mock(() => {})
+  const mockRunOnSingleObject = mock(() => ({ newData: {} }) as never)
   const mockRunOnMultipleObject = mock(() => {})
 
   const mockInitializeHook = spyOn(hooks, 'initializeHook').mockReturnValue({
@@ -368,7 +368,7 @@ describe('DatabaseController', () => {
     })
     expect(mockRunOnSingleObject).toHaveBeenNthCalledWith(2, {
       operationType: hooks.OperationType.AfterRead,
-      object: {},
+      id: 'id',
     })
   })
 
@@ -401,7 +401,7 @@ describe('DatabaseController', () => {
     })
     expect(mockRunOnMultipleObject).toHaveBeenNthCalledWith(2, {
       operationType: hooks.OperationType.AfterRead,
-      objects: [],
+      where: { id: { equalTo: 'id' } },
     })
   })
 
@@ -440,7 +440,7 @@ describe('DatabaseController', () => {
     })
     expect(mockRunOnSingleObject).toHaveBeenNthCalledWith(2, {
       operationType: hooks.OperationType.AfterUpdate,
-      object: { id: 'id' },
+      id: 'id',
     })
   })
 
@@ -479,7 +479,7 @@ describe('DatabaseController', () => {
     })
     expect(mockRunOnMultipleObject).toHaveBeenNthCalledWith(2, {
       operationType: hooks.OperationType.AfterUpdate,
-      objects: [],
+      ids: [],
     })
   })
 
@@ -512,9 +512,7 @@ describe('DatabaseController', () => {
     })
     expect(mockRunOnSingleObject).toHaveBeenNthCalledWith(2, {
       operationType: hooks.OperationType.AfterCreate,
-      object: {
-        id: 'id',
-      },
+      id: 'id',
     })
   })
 
@@ -552,7 +550,7 @@ describe('DatabaseController', () => {
     })
     expect(mockRunOnMultipleObject).toHaveBeenNthCalledWith(2, {
       operationType: hooks.OperationType.AfterCreate,
-      objects: [{ id: 'id' }],
+      ids: ['id'],
     })
 
     mockRunOnMultipleObject.mockClear()
@@ -621,6 +619,9 @@ describe('DatabaseController', () => {
     })
     expect(mockRunOnMultipleObject).toHaveBeenNthCalledWith(4, {
       operationType: hooks.OperationType.AfterDelete,
+      where: {
+        id: { equalTo: 'id' },
+      },
     })
 
     mockRunOnMultipleObject.mockClear()

--- a/packages/wabe/src/hooks/index.test.ts
+++ b/packages/wabe/src/hooks/index.test.ts
@@ -143,7 +143,8 @@ describe('Hooks', () => {
     // @ts-expect-error
     const hookObject = mockCallback3.mock.calls[0][0] as any
 
-    expect(hookObject.object).toEqual({ name: 'test' })
+    // Before create the object is empty
+    expect(hookObject.object).toEqual({})
 
     expect(hookObject.context).toEqual({
       isRoot: true,

--- a/packages/wabe/src/hooks/setupAcl.ts
+++ b/packages/wabe/src/hooks/setupAcl.ts
@@ -94,7 +94,7 @@ const setAcl = async ({
   }
 
   if (isBeforeHook) hookObject.upsertNewData('acl', aclObject)
-  else {
+  else
     await hookObject.context.wabe.controllers.database.updateObject({
       className: hookObject.className,
       context: { ...hookObject.context, isRoot: true },
@@ -104,13 +104,13 @@ const setAcl = async ({
       },
       fields: [],
     })
-  }
 }
 
 export const defaultSetupAclBeforeCreate = async (
   hookObject: HookObject<any, any>,
 ) => {
   const userId = hookObject.getUser()?.id
+
   if (hookObject.className === 'User' || !userId) return
 
   await setAcl({ hookObject, userId, isBeforeHook: true })

--- a/packages/wabe/src/schema/resolvers/sendOtpCode.test.ts
+++ b/packages/wabe/src/schema/resolvers/sendOtpCode.test.ts
@@ -83,7 +83,7 @@ describe('sendOtpCodeResolver', () => {
   it("should send an OTP code to the user's email as anonymous client", async () => {
     const anonymousClient = getAnonymousClient(port)
 
-    await anonymousClient.request<any>(graphql.createUser, {
+    await anonymousClient.request<any>(graphql.createUserWithAnonymous, {
       input: {
         fields: {
           authentication: {
@@ -133,6 +133,13 @@ const graphql = {
           user {
             id
           }
+        }
+      }
+    `,
+  createUserWithAnonymous: gql`
+      mutation createUser($input: CreateUserInput!) {
+        createUser(input: $input) {
+          ok
         }
       }
     `,


### PR DESCRIPTION
Now the DatabaseController is the only owner of the read logic after mutation operation. Database adapter should only return the id(s) of the mutate objects. More secure, less read useless operations

Persist only one issue, an anonymous that creates an user can't get the id of this user if he don't have the permission to read user. Because with ACL if only the user that create an object can access to it, an anonymous is not connected yet so he can't access to the user object. Seems weird but logic after reflection.