### PR TITLE
feat(wabe): add sensitive errors handling

### DIFF
--- a/packages/wabe/src/authentication/providers/EmailPassword.ts
+++ b/packages/wabe/src/authentication/providers/EmailPassword.ts
@@ -35,15 +35,25 @@ export class EmailPassword
       first: 1,
     })
 
+    const { showSensitiveErrors } = context.wabe.config.security || {}
+
     if (users.length === 0)
-      throw new Error('Invalid authentication credentials')
+      throw new Error(
+        showSensitiveErrors
+          ? 'Username not found in database'
+          : 'Invalid authentication credentials',
+      )
 
     const user = users[0]
 
     const userDatabasePassword = user?.authentication?.emailPassword?.password
 
     if (!userDatabasePassword)
-      throw new Error('Invalid authentication credentials')
+      throw new Error(
+        showSensitiveErrors
+          ? 'User has no password set up'
+          : 'Invalid authentication credentials',
+      )
 
     const isPasswordEquals = await verify(
       userDatabasePassword,
@@ -57,7 +67,11 @@ export class EmailPassword
       !isPasswordEquals ||
       input.email !== user.authentication?.emailPassword?.email
     )
-      throw new Error('Invalid authentication credentials')
+      throw new Error(
+        showSensitiveErrors
+          ? 'Password or email are not matching'
+          : 'Invalid authentication credentials',
+      )
 
     return {
       user,
@@ -80,8 +94,14 @@ export class EmailPassword
       context: contextWithRoot(context),
     })
 
-    // Hide real message
-    if (users > 0) throw new Error('Not authorized to create user')
+    const { showSensitiveErrors } = context.wabe.config.security || {}
+
+    if (users > 0)
+      throw new Error(
+        showSensitiveErrors
+          ? 'User already exists in database'
+          : 'Not authorized to create user',
+      )
 
     return {
       authenticationDataToSave: {
@@ -110,7 +130,14 @@ export class EmailPassword
       select: { authentication: true },
     })
 
-    if (users.length === 0) throw new Error('User not found')
+    const { showSensitiveErrors } = context.wabe.config.security || {}
+
+    if (users.length === 0)
+      throw new Error(
+        showSensitiveErrors
+          ? 'User not found'
+          : 'Not authorized to update user credentials',
+      )
 
     const user = users[0]
 

--- a/packages/wabe/src/server/index.ts
+++ b/packages/wabe/src/server/index.ts
@@ -32,6 +32,14 @@ type SecurityConfig = {
   corsOptions?: CorsOptions
   rateLimit?: RateLimitOptions
   maskErrorMessage?: boolean
+  /**
+   * Some errors may contain some sensitive informations that should not be
+   * shown in production for security reasons. Use this with great caution.
+   *
+   * If this parameter is falsy, it will show a generic sensitive free error
+   * message instead.
+   */
+  showSensitiveErrors?: boolean
 }
 
 export * from './interface'


### PR DESCRIPTION
I started implementing https://github.com/palixir/wabe/issues/74.

Before doing some tests of my solution and searching in all codebase for errors messages, I would like to have your opinion about a problem that I feel may occur with this simple solution.

Let's imagine that for some reason, we would need to automatically re-try on invalid authentication credential error. Without my changes, we would do something like this:
```typescript
try {
  // let's put aside all DI considerations and call it directly
  await onSignIn({ ... })
} catch (e) {
  if (e.message.contains('Invalid authentication credentials'))
    // do something
}
```
With those changing errors messages from one little and obscure parameter, it will be hard to correctly implement it, and would be very likely to introduce bugs.

This is one of two things:
- either this is a use case that should never happen the way Wabe is built, and I am overthinking the problem, which is very likely to be considering my very little experience on this project,
- or we would need a better custom error handling system for wabe components, which I think is quite out of scope of this issue
