### PR TITLE
minor docstring fixups

### DIFF
--- a/packages/wabe-documentation/docs/documentation/security/index.md
+++ b/packages/wabe-documentation/docs/documentation/security/index.md
@@ -152,7 +152,7 @@ const setAclOnCompany = async (hookObject: HookObject<any, any>) => {
         write: true,
       },
     ],
-    // Array of roles with acces on read and write for each one
+    // Array of roles with access on read and write for each one
     roles: [
       {
         roleId: "roleId",

--- a/packages/wabe-documentation/docs/documentation/wabe/start.md
+++ b/packages/wabe-documentation/docs/documentation/wabe/start.md
@@ -96,6 +96,6 @@ You’ll arrive at a GraphiQL interface with an online playground that allows yo
 
 In this interface, you’ll see that some queries are already created. By default, `Wabe` provides three classes: one class for users (with various elements, including authentication), a `Session` class to manage user sessions, and the last one corresponds to `Roles`. Any roles you create (see the Schema section) will be automatically added to the Role class and included in the RoleEnum enum.
 
-![GraphQL Playground wiht all default resolvers](/graphqlPlayground2.webp)
+![GraphQL Playground with all default resolvers](/graphqlPlayground2.webp)
 
 For each class you define, two queries and six mutations will be automatically generated to allow you to interact with your data. This will be explained in more detail in the Schema section.


### PR DESCRIPTION
Hey team! Fixed errors:

packages/wabe-documentation/docs/documentation/security/index.md
`acces` - `access`

packages/wabe-documentation/docs/documentation/wabe/start.md
`wiht` - `with`