### PR TITLE
Fix Typos in Comments and Test Descriptions

### DIFF
--- a/packages/wabe-postgres/src/index.test.ts
+++ b/packages/wabe-postgres/src/index.test.ts
@@ -1808,7 +1808,7 @@ describe('Postgres adapter', () => {
     )
   })
 
-  it('should update the same field of an objet that which we use in the where field', async () => {
+  it('should update the same field of an object that which we use in the where field', async () => {
     const insertedObject = await postgresAdapter.createObject({
       className: 'User',
       data: {

--- a/packages/wabe/src/server/index.ts
+++ b/packages/wabe/src/server/index.ts
@@ -255,7 +255,7 @@ export class Wabe<T extends WabeTypes> {
       })
 
       // If we just want codegen we exit before server created.
-      // Not the best solution but usefull to avoid multiple source of truth
+      // Not the best solution but useful to avoid multiple source of truth
       if (process.env.CODEGEN) process.exit(0)
     }
 


### PR DESCRIPTION


Description:  
This pull request corrects minor spelling mistakes in the codebase:
- In the Postgres adapter test, "objet" is corrected to "object".
- In the server index file, "usefull" is corrected to "useful" in a comment.

These changes improve code readability and maintain consistency in documentation and comments. No functional code was modified.