### PR TITLE
Fix Typo in French Comment and Correct Test Description

### DIFF
--- a/packages/wabe-documentation/components/landing/presentation.tsx
+++ b/packages/wabe-documentation/components/landing/presentation.tsx
@@ -15,7 +15,7 @@ const view = () => (
         </p>
       </div>
 
-      {/* Liste des projets */}
+      {/* Liste des projects */}
       <div className="flex flex-col items-center gap-6 text-center">
         <ul className="list-inside space-y-4 text-left text-lg text-gray-500 max-w-4xl">
           <li className="flex items-start gap-4">

--- a/packages/wabe-mongodb/src/index.test.ts
+++ b/packages/wabe-mongodb/src/index.test.ts
@@ -1737,7 +1737,7 @@ describe('Mongo adapter', () => {
     )
   })
 
-  it('should update the same field of an objet that which we use in the where field', async () => {
+  it('should update the same field of an object that which we use in the where field', async () => {
     const insertedObject = await mongoAdapter.createObject({
       className: 'User',
       data: {


### PR DESCRIPTION


Description:  
This pull request makes minor corrections in two files:
- In the `presentation.tsx` file, the French comment for the project list was corrected from "projets" to "projects".
- In the `index.test.ts` file, the test description was updated to fix a typo, changing "object" from "objet".

These changes improve code clarity and maintain consistency in comments and test descriptions. No functional code was altered.