### PR TITLE
Fix Typo: Rename formatedFields to formattedFields in parseGraphqlSchema.ts

### DIFF
--- a/packages/wabe/src/graphql/parseGraphqlSchema.ts
+++ b/packages/wabe/src/graphql/parseGraphqlSchema.ts
@@ -58,7 +58,7 @@ const _getTypeFields = (
   // @ts-expect-error
   const fields = (type?.getFields?.() || {}) as Record<string, any>
 
-  const formatedFields = Object.entries(fields).reduce(
+  const formattedFields = Object.entries(fields).reduce(
     (acc, [fieldName, fieldType]) => ({
       ...acc,
       [fieldName]: fieldType.type.toString(),
@@ -67,7 +67,7 @@ const _getTypeFields = (
   )
 
   return {
-    input: formatedFields,
+    input: formattedFields,
   }
 }
 


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the variable name from formatedFields to formattedFields within the parseGraphqlSchema.ts file. The change improves code readability and consistency. No functional changes were made; only the variable name was updated.